### PR TITLE
Increased wait group before pushing to channel

### DIFF
--- a/group.go
+++ b/group.go
@@ -36,8 +36,8 @@ func (g *Group) Add(function func()) error {
 		return errors.New(nilFunctionError)
 	}
 
-	g.jobsChannel <- function
 	g.waitGroup.Add(1)
+	g.jobsChannel <- function
 	return nil
 }
 


### PR DESCRIPTION
to avoid race condition on calling waitGroup.Done()
```
panic: sync: negative WaitGroup counter
```
